### PR TITLE
fix: amend group name for JUnit to make project buildable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation( group:'org.junit', name:'junit', version:'4.13.2')
+    testImplementation( group:'junit', name:'junit', version:'4.13.2')
     testImplementation( group:'org.hamcrest', name:'hamcrest', version:'2.2')
     testImplementation( group:'org.hamcrest', name:'hamcrest-core', version:'2.2')
 }


### PR DESCRIPTION
Previously, the group name for JUnit was incorrect, causing the project to fail to build. This commit fixes the issue by updating the group name to the correct value.

Resolves #1